### PR TITLE
fix bug - LLM response on empty input string

### DIFF
--- a/app/backend/approaches/chatapproach.py
+++ b/app/backend/approaches/chatapproach.py
@@ -14,6 +14,8 @@ class ChatApproach(Approach, ABC):
         {"role": "assistant", "content": "Provide a list of common flu symptoms"},
         {"role": "user", "content": "How can I manage high blood pressure?"},
         {"role": "assistant", "content": "Suggest ways to manage high blood pressure"},
+        {"role": "user", "content": " "},
+        {"role": "assistant", "content": ""},
     ]
     NO_RESPONSE = "0"
 

--- a/app/backend/approaches/chatreadretrieveread.py
+++ b/app/backend/approaches/chatreadretrieveread.py
@@ -146,7 +146,7 @@ class ChatReadRetrieveReadApproach(ChatApproach):
         if profile.profile_type == "general":
             user_query_request = "Generate search query for: " + original_user_query
         else:
-            stripped_text_check = original_user_query.replace(" ", "") # check if user input is an empty string
+            stripped_text_check = original_user_query.replace(" ", "")  # check if user input is an empty string
             if not stripped_text_check:
                 user_query_request = "Generate search query for: " + original_user_query
             else:

--- a/app/backend/approaches/chatreadretrieveread.py
+++ b/app/backend/approaches/chatreadretrieveread.py
@@ -146,7 +146,11 @@ class ChatReadRetrieveReadApproach(ChatApproach):
         if profile.profile_type == "general":
             user_query_request = "Generate search query for: " + original_user_query
         else:
-            user_query_request = f"Generate search query for: {original_user_query}, user profile: {age_group}, {profile.user_gender}, age {profile.user_age}, {profile.user_condition}"
+            stripped_text_check = original_user_query.replace(" ", "") # check if user input is an empty string
+            if not stripped_text_check:
+                user_query_request = "Generate search query for: " + original_user_query
+            else:
+                user_query_request = f"Generate search query for: {original_user_query}, user profile: {age_group}, {profile.user_gender}, age {profile.user_age}, {profile.user_condition}"
 
         tools: List[ChatCompletionToolParam] = [
             {

--- a/app/backend/approaches/prompts.py
+++ b/app/backend/approaches/prompts.py
@@ -109,6 +109,7 @@ Do not include cited source filenames and document names e.g info.txt or doc.pdf
 Do not include any text inside [] or <<>> in the search query terms.
 Do not include any special characters like '+'.
 If the question is not in English, translate the question to English before generating the search query.
+If the question is empty, return just the number 0.
 If you cannot generate a search query, return just the number 0.
 """
 


### PR DESCRIPTION
Updated:
1. prompts.py: edited query text generation prompt
2. chatapproach.py: edited query_prompt_few_shots
3. chatreadretrieveread.py: input check for empty string. if empty, user profile will be excluded in user_query_request