### PR TITLE
Update monitoring bicep

### DIFF
--- a/infra/core/monitor/monitoring.bicep
+++ b/infra/core/monitor/monitoring.bicep
@@ -8,7 +8,7 @@ param tags object = {}
 param publicNetworkAccess string = 'Enabled'
 
 module logAnalytics 'br/public:avm/res/operational-insights/workspace:0.4.0' = {
-  name: 'loganalytics'
+  name: logAnalyticsName
   params: {
     name: logAnalyticsName
     location: location
@@ -22,7 +22,7 @@ module logAnalytics 'br/public:avm/res/operational-insights/workspace:0.4.0' = {
 }
 
 module applicationInsights 'br/public:avm/res/insights/component:0.3.1' = {
-  name: 'applicationinsights'
+  name: applicationInsightsName
   params: {
     name: applicationInsightsName
     location: location
@@ -34,7 +34,7 @@ module applicationInsights 'br/public:avm/res/insights/component:0.3.1' = {
 }
 
 module applicationInsightsDashboard 'applicationinsights-dashboard.bicep' = if (!empty(applicationInsightsDashboardName)) {
-  name: 'application-insights-dashboard'
+  name: !empty(applicationInsightsDashboardName) ? applicationInsightsDashboardName: 'application-insights-dashboard'
   params: {
     name: applicationInsightsDashboardName
     location: location


### PR DESCRIPTION
### monitoring.bicep
- Update logAnalytics, applicationInsights and applicationInsightsDashboard module to use param(name) passed to it for the name variable instead of using a fixed string.
    > This is because " if two Bicep files use the same module with the same static name (examplemodule) and targeted to the same resource group, one deployment might show the wrong output. If you're concerned about concurrent deployments to the same scope, give your module a unique name."
- applicationInsightsDashboard module
    - Although `if (!empty(applicationInsightsDashboardName))` prevents deployment when the string is empty, bicep still checks if the module name is empty. Hence i added a ternary operator to handle empty string.